### PR TITLE
Fix: Correct syntax error in configure_session_lock.sh and refine SSH…

### DIFF
--- a/setup_firewall.sh
+++ b/setup_firewall.sh
@@ -36,25 +36,57 @@ echo "Default incoming policy set to deny."
 ufw default allow outgoing
 echo "Default outgoing policy set to allow."
 
-echo "Allowing SSH connections..."
-# Allow SSH (port 22). This is crucial to avoid being locked out.
-if ufw status | grep -qw "22/tcp"; then
-    echo "SSH (port 22/tcp) is already allowed."
-else
-    ufw allow ssh
-    echo "SSH (port 22/tcp) has been allowed."
+echo "Checking for SSH service/application profile in ufw..."
+
+SSH_APP_PROFILE_FOUND=false
+SSH_PORT_ALLOWED=false
+
+# Check if SSH port (22/tcp) is already allowed
+if ufw status | grep -Ewq "22/tcp\s*(ALLOW|ALLOWED)" ; then
+    echo "SSH port 22/tcp is already allowed."
+    SSH_PORT_ALLOWED=true
+# Check if OpenSSH app profile is already allowed
+elif ufw status | grep -Ewq "OpenSSH\s*(ALLOW|ALLOWED)" ; then
+    echo "OpenSSH application profile is already allowed."
+    SSH_PORT_ALLOWED=true
 fi
 
-if ufw status | grep -qw "OpenSSH"; then
-    echo "SSH (OpenSSH service) is already allowed."
+if [ "$SSH_PORT_ALLOWED" = false ]; then
+    # Check for ufw application profiles for SSH
+    if ufw app list | grep -qiw OpenSSH; then
+        echo "OpenSSH application profile found. Allowing OpenSSH..."
+        ufw allow OpenSSH
+        echo "OpenSSH application profile allowed."
+        SSH_APP_PROFILE_FOUND=true
+    elif ufw app list | grep -qiw ssh; then
+        echo "ssh application profile found. Allowing ssh..."
+        ufw allow ssh
+        echo "ssh application profile allowed."
+        SSH_APP_PROFILE_FOUND=true
+    else
+        echo "No ufw application profile found for SSH (OpenSSH or ssh)."
+        # As per requirement, do not attempt to add port 22/tcp if service not found.
+        # Check if an SSH server is even installed/running for a more informative message.
+        if command -v sshd >/dev/null || systemctl list-units --type=service | grep -q sshd.service; then
+            echo "Warning: An SSH server seems to be installed, but no ufw profile was found."
+            echo "If you use SSH, you may need to manually allow port 22: 'sudo ufw allow 22/tcp'"
+        else
+            echo "SSH server does not appear to be installed. Port 22/tcp will not be opened."
+        fi
+    fi
 else
-    ufw allow OpenSSH
-    echo "SSH (OpenSSH service) has been allowed."
+    echo "SSH is already explicitly allowed. No changes made by this script for SSH rules."
 fi
-
 
 echo "Reloading ufw to apply changes..."
-ufw reload
+# Reload only if ufw is active, otherwise enable might have handled it or it's not needed.
+if ufw status | grep -q "Status: active"; then
+    ufw reload
+else
+    # If ufw was just enabled, it's often reloaded automatically.
+    # If it's inactive and wasn't enabled by this script, reload won't work.
+    echo "ufw is not active, reload is not applicable or already handled by enable."
+fi
 echo "ufw reloaded."
 
 echo "Current ufw status:"


### PR DESCRIPTION
… handling in setup_firewall.sh

- configure_session_lock.sh: Fixed a bash syntax error in the KDE Plasma configuration block where an `if` condition was not properly followed by `then`.
- setup_firewall.sh: Modified the SSH rule logic to first check for existing `ufw` application profiles (OpenSSH or ssh). If no profile is found, the script no longer attempts to add a rule for port 22/tcp and informs the user. This prevents errors if SSH is not installed or not available as a ufw app, and makes the SSH port opening conditional on service presence.